### PR TITLE
Add CSV target language

### DIFF
--- a/src/main/scala/com/typesafe/sbt/SbtLicenseReport.scala
+++ b/src/main/scala/com/typesafe/sbt/SbtLicenseReport.scala
@@ -20,6 +20,7 @@ object SbtLicenseReport extends AutoPlugin {
     def LicenseReportConfiguration = com.typesafe.sbt.license.LicenseReportConfiguration
     def Html = com.typesafe.sbt.license.Html
     def MarkDown = com.typesafe.sbt.license.MarkDown
+    def Csv = com.typesafe.sbt.license.Csv
     
     // Keys
     val updateLicenses = taskKey[LicenseReport]("Construct a report of used licenses in a project.")
@@ -59,11 +60,11 @@ object SbtLicenseReport extends AutoPlugin {
       // TODO - Maybe we need a general purpose reporting directory
       licenseReportDir := target.value / "license-reports",
       licenseReportStyleRules := None,
-      licenseReportTypes := Seq(MarkDown, Html),
+      licenseReportTypes := Seq(MarkDown, Html, Csv),
       licenseReportConfigurations := {
         val dir = licenseReportDir.value
         val styleRules = licenseReportStyleRules.value
-        // TODO - Configurable language (markdown/html) rather than both always
+        // TODO - Configurable language (markdown/html/csv) rather than all always
         val reportTypes = licenseReportTypes.value
         val notesLookup = licenseReportNotes.value.lift
         val config = LicenseReportConfiguration(licenseReportTitle.value, reportTypes, licenseReportMakeHeader.value, notesLookup, licenseFilter.value, dir, styleRules)

--- a/src/main/scala/com/typesafe/sbt/license/TargetLanguage.scala
+++ b/src/main/scala/com/typesafe/sbt/license/TargetLanguage.scala
@@ -13,8 +13,6 @@ sealed trait TargetLanguage {
   def blankLine(): String
   /** Creates something equivalent to an html &lt;h1&gt; tag. */
   def header1(msg: String): String
-  /** Creates something equivalent to an html &lt;h4&gt; tag. */
-  def header4(msg: String): String
   /** The syntax for the header of a table. */
   def tableHeader(firstColumn: String, secondColumn: String, thirdColumn: String, fourthColumn: String): String
   /** The syntax for a row of a table. */
@@ -32,7 +30,6 @@ case object MarkDown extends TargetLanguage {
   def createHyperLink(link: String, content: String): String =
     s"[$content]($link)"
   def blankLine(): String = "\n"
-  def header4(msg: String): String = s"#### $msg\n"
   def header1(msg: String): String = s"# $msg\n"
   def tableHeader(firstColumn: String, secondColumn: String, thirdColumn: String, fourthColumn: String): String =
     s"""
@@ -66,7 +63,6 @@ case object Html extends TargetLanguage {
     s"""<a href="$link">$content</a>"""
   def blankLine(): String = "<p>&nbsp;</p>"
   def header1(msg: String): String = s"<h1>$msg</h1>"
-  def header4(msg: String): String = s"<h4>$msg</h4>"
   def tableHeader(firstColumn: String, secondColumn: String, thirdColumn: String, fourthColumn: String): String =
     s"""<table border="0" cellspacing="0" cellpading="1">
       <thead><tr><th>$firstColumn</th><th>$secondColumn</th><th>$thirdColumn</th><th>$fourthColumn</th></tr></thead>
@@ -76,4 +72,21 @@ case object Html extends TargetLanguage {
   def tableEnd: String = "</tbody></table>"
 
   def htmlEncode(s: String) = org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(s)
+}
+
+case object Csv extends TargetLanguage {
+  val ext = "csv"
+  def documentStart(title: String, reportStyleRules: Option[String]): String = ""
+  def documentEnd(): String = ""
+  def createHyperLink(link: String, content: String): String = {
+    if (link != null && !link.trim().isEmpty()) s"$content ($link)" else s"$content"
+  }
+  def blankLine(): String = ""
+  def header1(msg: String): String = ""
+  def tableHeader(firstColumn: String, secondColumn: String, thirdColumn: String, fourthColumn: String): String =
+    tableRow(firstColumn, secondColumn, thirdColumn, fourthColumn)
+  def tableRow(firstColumn: String, secondColumn: String, thirdColumn: String, fourthColumn: String): String =
+    s"""${csvEncode(firstColumn)},${csvEncode(secondColumn)},${csvEncode(thirdColumn)},${csvEncode(fourthColumn)}\n"""
+  def tableEnd: String = ""
+  def csvEncode(s: String): String = org.apache.commons.lang3.StringEscapeUtils.escapeCsv(s)
 }

--- a/src/sbt-test/dumpLicenseReport/custom-report/test
+++ b/src/sbt-test/dumpLicenseReport/custom-report/test
@@ -2,3 +2,4 @@
 $ exists target/license-reports/lreport.md
 > check
 $ exists target/license-reports/test-config.html
+-$ exists target/license-reports/lreport.csv

--- a/src/sbt-test/dumpLicenseReport/default-report/test
+++ b/src/sbt-test/dumpLicenseReport/default-report/test
@@ -1,4 +1,5 @@
 > dumpLicenseReport
 $ exists target/license-reports/example-licenses.md
 $ exists target/license-reports/example-licenses.html
+$ exists target/license-reports/example-licenses.csv
 > check


### PR DESCRIPTION
Prior to this change, there were two "target languages" for the license report output: Markdown and HTML. Both output formats are optimized for human consumption.

This change adds a third target language: [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) (comma-separated values). The CSV version of the license report is a machine-readable data file that is useful when users want the license report output to become the input for another tool.

In order to create the new target language, I created a new case object that extends the `TargetLanguage` trait.  `TargetLanguage` was clearly designed with the idea that it would be used to define human-readable output, but I feel like the CSV format is close enough to the other output formats that I didn't have to do too much violence to the `TargetLanguage` concept.

One caveat: `TargetLanguage` has a property called `header4`, which a comment describes as "something equivalent to an html &lt;h4&gt; tag." If the idea is to partition the license report output into sections, this is a problem for the CSV format. There are only two ways to partition CSV data: create separate files for the different partitions, or add a column that identifies the partition each row belongs to. Neither approach is an option here. Fortunately, it appears the `header4` property is unused by the code that generates the license report. A code comment says `TargetLanguage` was "Borrowed from scala/make-release-notes." I assume that `header4` is a vestige reflecting its historical origins and will not be used in the future.