### PR TITLE
Print license info for licenses where we haven't defined a category yet

### DIFF
--- a/src/main/scala/com/typesafe/sbt/license/LicenseCategory.scala
+++ b/src/main/scala/com/typesafe/sbt/license/LicenseCategory.scala
@@ -32,6 +32,7 @@ object LicenseCategory {
   val CDDL = LicenseCategory("CDDL", Seq("Common Development and Distribution"))
   val Proprietary = LicenseCategory("Proprietary")
   val NoneSpecified = LicenseCategory("none specified")
+  val Unrecognized = LicenseCategory("unrecognized")
 
   val all: Seq[LicenseCategory] =
     Seq(PublicDomain, CommonPublic, CC0, Mozilla, MIT, BSD, Apache, LGPL, GPLClasspath, GPL, EPL, CDDL, Proprietary)

--- a/src/sbt-test/dumpLicenseReport/default-report/example.sbt
+++ b/src/sbt-test/dumpLicenseReport/default-report/example.sbt
@@ -1,6 +1,7 @@
 name := "example"
 
 libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.4"
+libraryDependencies += "junit"                      % "junit"            % "4.12"  % "test"
 
 excludeDependencies += SbtExclusionRule(organization = "org.scala-lang")
 
@@ -8,6 +9,10 @@ TaskKey[Unit]("check") := {
   val contents = sbt.IO.read(target.value / "license-reports" / "example-licenses.md")
   if (!contents.contains("[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | com.fasterxml.jackson.core # jackson-databind # 2.5.4"))
     sys.error("Expected report to contain jackson-databind with Apache license: " + contents)
+  if (!contents.contains("jackson-databind"))
+    sys.error("Expected report to contain jackson-databind: " + contents)
+  if (!contents.contains("[Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html) | junit # junit # 4.12"))
+    sys.error("Expected report to contain junit with EPL license: " + contents)
   // Test whether exclusions are included.
   if (contents.contains("scala-library"))
     sys.error("Expected report to NOT contain scala-library: " + contents)


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-license-report/issues/16. If you're auditing licenses for legal/compliance purposes you want to print them all. Not just licenses that sbt-license-report explicitly knows something about. Junit uses EPL, which is fairly common, so we can also add support for EPL, AGPL, and other common licenses that aren't included right now, but regardless there will always be new licenses that aren't in our list and we still need to print them