### PR TITLE
Cross build for SBT 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-jdk: openjdk8
+jdk: oraclejdk8
 script:
   - sbt "++${TRAVIS_SCALA_VERSION}" "^^${SBT_VERSION}" scripted
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: scala
+jdk: openjdk8
 script:
   - sbt "++${TRAVIS_SCALA_VERSION}" "^^${SBT_VERSION}" scripted
 matrix:
   include:
   - env: SBT_VERSION="0.13.16"
-    jdk: openjdk7
     scala: 2.10.6
   - env: SBT_VERSION="1.0.0"
-    jdk: oraclejdk8
     scala: 2.12.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
 language: scala
-script: "sbt scripted"
+script:
+  - sbt "++${TRAVIS_SCALA_VERSION}" "^^${SBT_VERSION}" scripted
+matrix:
+  include:
+  - env: SBT_VERSION="0.13.16"
+    jdk: openjdk7
+    scala: 2.10.6
+  - env: SBT_VERSION="1.0.0"
+    jdk: oraclejdk8
+    scala: 2.12.3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sbt-license-report
 
 This plugin will allow you to report the licenses used in your projects.  It requires
-sbt 0.13.5+
+sbt 0.13.8+ or 1.0.0
 
 ## Installation
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ organization := "com.typesafe.sbt"
 name := "sbt-license-report"
 
 sbtPlugin := true
+crossSbtVersions := Seq("0.13.16", "1.0.0")
 
 publishMavenStyle := false
 bintrayOrganization := Some("sbt")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/src/main/scala-sbt-0.13/com/typesafe/sbt/license/SbtCompat.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbt/license/SbtCompat.scala
@@ -1,0 +1,5 @@
+package com.typesafe.sbt
+package
+
+object SbtCompat {
+}

--- a/src/main/scala-sbt-0.13/com/typesafe/sbt/license/SbtCompat.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbt/license/SbtCompat.scala
@@ -1,5 +1,5 @@
 package com.typesafe.sbt
-package
+package license
 
 object SbtCompat {
 }

--- a/src/main/scala-sbt-1.0/com/typesafe/sbt/license/SbtCompat.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbt/license/SbtCompat.scala
@@ -1,0 +1,9 @@
+package com.typesafe.sbt
+package license
+
+object SbtCompat {
+  val Using = sbt.io.Using
+  val IvyRetrieve = sbt.internal.librarymanagement.IvyRetrieve
+  type IvySbt = sbt.internal.librarymanagement.IvySbt
+  type ResolveException = sbt.librarymanagement.ResolveException
+}

--- a/src/main/scala/com/typesafe/sbt/license/LicenseReport.scala
+++ b/src/main/scala/com/typesafe/sbt/license/LicenseReport.scala
@@ -4,6 +4,7 @@ package license
 import sbt._
 import org.apache.ivy.core.report.ResolveReport
 import org.apache.ivy.core.resolve.IvyNode
+import SbtCompat._
 
 case class DepModuleInfo(organization: String, name: String, version: String) {
   override def toString = s"${organization} # ${name} # ${version}"

--- a/src/sbt-test/dumpLicenseReport/default-report/example.sbt
+++ b/src/sbt-test/dumpLicenseReport/default-report/example.sbt
@@ -3,7 +3,7 @@ name := "example"
 libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.4"
 libraryDependencies += "junit"                      % "junit"            % "4.12"  % "test"
 
-excludeDependencies += SbtExclusionRule(organization = "org.scala-lang")
+excludeDependencies += "org.scala-lang"
 
 TaskKey[Unit]("check") := {
   val contents = sbt.IO.read(target.value / "license-reports" / "example-licenses.md")


### PR DESCRIPTION
Should take care of #35.

I inferred from SBT release notes `excludeDependencies` change requires 0.13.8+, hence the bump in the README. Didn't do any testing with earlier SBT 0.13 versions though so I may well be wrong.