### PR TITLE
Properly prune dumpLicenseInfo reports

### DIFF
--- a/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
@@ -117,14 +117,14 @@ object SbtLicenseReport extends AutoPlugin {
         val reports = aggregateUpdateLicenses.value
         val dir = licenseReportDir.value
         for (config <- licenseReportConfigurations.value)
-          LicenseReport.dumpLicenseReport(reports.flatMap(_.licenses).distinct, config)
+          LicenseReport.dumpLicenseReport(reports.flatMap(_.licenses), config)
         dir
       },
       dumpLicenseReportAnyProject := {
         val reports = anyProjectUpdateLicenses.value
         val dir = licenseReportDir.value
         for (config <- licenseReportConfigurations.value)
-          LicenseReport.dumpLicenseReport(reports.flatMap(_.licenses).distinct, config)
+          LicenseReport.dumpLicenseReport(reports.flatMap(_.licenses), config)
         dir
       }
     )

--- a/src/main/scala/sbtlicensereport/license/LicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseReport.scala
@@ -34,7 +34,10 @@ object LicenseReport {
     }
   }
 
-  def dumpLicenseReport(reportLicenses: Seq[DepLicense], config: LicenseReportConfiguration): Unit = {
+  def dumpLicenseReport(
+      reportLicenses: Seq[DepLicense],
+      config: LicenseReportConfiguration
+  ): Unit = {
     import config._
     val ordered = reportLicenses.filter(l => licenseFilter(l.license.category)) sortWith {
       case (l, r) =>
@@ -53,13 +56,17 @@ object LicenseReport {
         print(language.documentStart(title, reportStyleRules))
         print(makeHeader(language))
         print(language.tableHeader("Category", "License", "Dependency", "Notes"))
-        for (dep <- ordered) {
+        val rendered = (ordered map { dep =>
           val licenseLink = language.createHyperLink(dep.license.url, dep.license.name)
           val moduleLink = dep.homepage match {
             case None      => dep.module.toString
             case Some(url) => language.createHyperLink(url.toExternalForm, dep.module.toString)
           }
-          print(language.tableRow(dep.license.category.name, licenseLink, moduleLink, notes(dep.module) getOrElse ""))
+          (dep.license.category.name, licenseLink, moduleLink, notes(dep.module) getOrElse "")
+        }).distinct
+
+        for ((name, licenseLink, moduleLink, notes) <- rendered) {
+          print(language.tableRow(name, licenseLink, moduleLink, notes))
         }
         print(language.tableEnd)
         print(language.documentEnd)

--- a/src/sbt-test/dumpLicenseReport/prune-duplicates-report/example.sbt
+++ b/src/sbt-test/dumpLicenseReport/prune-duplicates-report/example.sbt
@@ -1,0 +1,30 @@
+name := "example"
+
+lazy val one = project
+  .in(file("one"))
+  .settings(
+    List(
+      libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % "2.5.4"
+    )
+  )
+
+lazy val two = project
+  .in(file("two"))
+  .settings(
+    List(
+      libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % "2.5.4" % Test
+    )
+  )
+
+def countOccurrences(src: String, tgt: String): Int =
+  src.sliding(tgt.length).count(window => window == tgt)
+
+TaskKey[Unit]("check") := {
+  val contents = sbt.IO.read(target.value / "license-reports" / "example-licenses.md")
+  val count = countOccurrences(contents, "com.fasterxml.jackson.core")
+  count match {
+    case 0           => sys.error("Expected a single occurance of jackson")
+    case n if n >= 2 => sys.error("Expected to only have one occurance of jackson" + contents)
+    case _           => ()
+  }
+}

--- a/src/sbt-test/dumpLicenseReport/prune-duplicates-report/project/plugins.sbt
+++ b/src/sbt-test/dumpLicenseReport/prune-duplicates-report/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-license-report" % sys.props("plugin.version"))

--- a/src/sbt-test/dumpLicenseReport/prune-duplicates-report/test
+++ b/src/sbt-test/dumpLicenseReport/prune-duplicates-report/test
@@ -1,0 +1,5 @@
+> dumpLicenseReportAnyProject
+$ exists target/license-reports/example-licenses.md
+$ exists target/license-reports/example-licenses.html
+$ exists target/license-reports/example-licenses.csv
+> check


### PR DESCRIPTION
In https://github.com/sbt/sbt-license-report/pull/55 I used `distinct` to filter out duplicate entries however it turns out there is a corner case which I missed regarding differing configs, i.e. dependency A in one sbt project its in `Test` config and in another project its in default config. This could happen because the `DepLicense` data structure that is derived from `updateLicense` contains the configs for that given dependency and so if they differ they won't get filtered out by `distinct`.

This PR solves the problem in a different way, which is to add a `dumpLicensePruneDuplicates` that works by pruning out the duplicates in the data structure that is used just before actually writing out the contexts. That way we have the behaviour that a user expects, i.e. not having the exact same rows generated in the report.

A test has been added which fails when you set `dumpLicensePruneDuplicates` to `false`.

@eed3si9n I have a couple more fixes incoming when I tried to use this within Pekko so I will let you know when to make a new release.