### PR TITLE
Add Eclipse Public License synonym for EPL

### DIFF
--- a/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
@@ -28,7 +28,7 @@ object LicenseCategory {
   val CommonPublic = LicenseCategory("Common Public License", Seq("cpl", "common public"))
   val PublicDomain = LicenseCategory("Public Domain")
   val CC0 = LicenseCategory("CC0", Seq("Creative Commons Zero"))
-  val EPL = LicenseCategory("EPL")
+  val EPL = LicenseCategory("EPL", Seq("Eclipse Public License"))
   val CDDL = LicenseCategory("CDDL", Seq("Common Development and Distribution"))
   val Proprietary = LicenseCategory("Proprietary")
   val NoneSpecified = LicenseCategory("none specified")


### PR DESCRIPTION
Found this when trying license-report-info on a project that uses JUnit (which has EPL license but its listed as `"Eclipse Public License"`)