### PR TITLE
Add Bouncy Castle license

### DIFF
--- a/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
@@ -30,12 +30,28 @@ object LicenseCategory {
   val CC0 = LicenseCategory("CC0", Seq("Creative Commons Zero"))
   val EPL = LicenseCategory("EPL")
   val CDDL = LicenseCategory("CDDL", Seq("Common Development and Distribution"))
+  val BouncyCastle = LicenseCategory("Bouncy Castle License", Seq("Bouncy Castle"))
   val Proprietary = LicenseCategory("Proprietary")
   val NoneSpecified = LicenseCategory("none specified")
   val Unrecognized = LicenseCategory("unrecognized")
 
   val all: Seq[LicenseCategory] =
-    Seq(PublicDomain, CommonPublic, CC0, Mozilla, MIT, BSD, Apache, LGPL, GPLClasspath, GPL, EPL, CDDL, Proprietary)
+    Seq(
+      PublicDomain,
+      CommonPublic,
+      CC0,
+      Mozilla,
+      MIT,
+      BSD,
+      Apache,
+      LGPL,
+      GPLClasspath,
+      GPL,
+      EPL,
+      CDDL,
+      BouncyCastle,
+      Proprietary
+    )
 
   def find(licenses: Seq[LicenseCategory])(licenseName: String): Option[LicenseCategory] =
     licenses.find(_.unapply(licenseName))

--- a/src/main/scala/sbtlicensereport/license/LicenseInfo.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseInfo.scala
@@ -55,4 +55,6 @@ object LicenseInfo {
     "http://www.eclipse.org/org/documents/edl-v10.php"
   )
   val MPL = LicenseInfo(LicenseCategory.Mozilla, "Mozilla Public License 2.0", "https://www.mozilla.org/MPL/2.0/")
+  val BouncyCastle =
+    LicenseInfo(LicenseCategory.BouncyCastle, "Bouncy Castle Licence", "https://www.bouncycastle.org/license.html")
 }


### PR DESCRIPTION
Adds the bouncy castle license. There are arguments for and against adding this license. The strongest obvious argument against adding it is that its bespoke for a project (bouncy castle). The argument for adding it however is that bouncy castle is one of the most critical/used Java projects so it has a high chance of cropping up.

If you don't feel that it belongs here just close the PR.