### PR TITLE
Add licenseDepExclusions to filter out unwanted deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ can be controlled via the following keys:
         LicenseInfo(LicenseCategory.BSD, "BSD-3-Clause", "http://opensource.org/licenses/BSD-3-Clause")
     }
 
+    // Want to exclude any artifacts from org.scala-lang organization. Note that transitive dependencies
+    // of a filtered DepModuleInfo will NOT get filtered out
+    licenseDepExclusions := {
+        case DepModuleInfo("org.scala-lang", _, _) => true
+    }
+
 # Releasing
 
 This plugin uses [sbt-ci-release](https://github.com/sbt/sbt-ci-release). To

--- a/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
@@ -15,6 +15,8 @@ object SbtLicenseReport extends AutoPlugin {
     def LicenseCategory = sbtlicensereport.license.LicenseCategory
     type TargetLanguage = sbtlicensereport.license.TargetLanguage
     type LicenseReportConfiguration = sbtlicensereport.license.LicenseReportConfiguration
+    type DepModuleInfo = sbtlicensereport.license.DepModuleInfo
+    val DepModuleInfo = sbtlicensereport.license.DepModuleInfo
     def LicenseReportConfiguration = sbtlicensereport.license.LicenseReportConfiguration
     def Html = sbtlicensereport.license.Html
     def MarkDown = sbtlicensereport.license.MarkDown
@@ -48,6 +50,9 @@ object SbtLicenseReport extends AutoPlugin {
     val licenseOverrides = settingKey[PartialFunction[DepModuleInfo, LicenseInfo]](
       "A list of license overrides for artifacts with bad infomration on maven."
     )
+    val licenseDepExclusions = settingKey[PartialFunction[DepModuleInfo, Boolean]](
+      "A partial function of which dependencies you want to exclude"
+    )
     val licenseFilter =
       settingKey[LicenseCategory => Boolean]("Configuration for what licenses to include in the report, by default.")
   }
@@ -71,15 +76,18 @@ object SbtLicenseReport extends AutoPlugin {
       // Here we use an empty partial function
       licenseReportNotes := PartialFunction.empty,
       licenseOverrides := PartialFunction.empty,
+      licenseDepExclusions := PartialFunction.empty,
       licenseFilter := TypeFunctions.const(true),
       updateLicenses := {
         val ignore = update.value
         val overrides = licenseOverrides.value.lift
+        val depExclusions = licenseDepExclusions.value.lift
         license.LicenseReport.makeReport(
           ivyModule.value,
           licenseConfigurations.value,
           licenseSelection.value,
           overrides,
+          depExclusions,
           streams.value.log
         )
       },

--- a/src/sbt-test/dumpLicenseReport/dep-exclusions-report/example.sbt
+++ b/src/sbt-test/dumpLicenseReport/dep-exclusions-report/example.sbt
@@ -1,0 +1,21 @@
+name := "example"
+
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.4"
+libraryDependencies += "junit"                      % "junit"            % "4.12"  % "test"
+
+excludeDependencies += "org.scala-lang"
+
+licenseDepExclusions := {
+  case DepModuleInfo("junit", _, _) => true
+}
+
+TaskKey[Unit]("check") := {
+  val contents = sbt.IO.read(target.value / "license-reports" / "example-licenses.md")
+  if (contents.contains("junit"))
+    sys.error("Expected report to NOT contain junit directly: " + contents)
+  if (!(contents.contains("hamcrest")))
+    sys.error("Expected report to contain hamcrest which is a transitive dependency of junit: " + contents)
+  // Test whether exclusions are included.
+  if (contents.contains("scala-library"))
+    sys.error("Expected report to NOT contain scala-library: " + contents)
+}

--- a/src/sbt-test/dumpLicenseReport/dep-exclusions-report/project/plugins.sbt
+++ b/src/sbt-test/dumpLicenseReport/dep-exclusions-report/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-license-report" % sys.props("plugin.version"))

--- a/src/sbt-test/dumpLicenseReport/dep-exclusions-report/test
+++ b/src/sbt-test/dumpLicenseReport/dep-exclusions-report/test
@@ -1,0 +1,5 @@
+> dumpLicenseReport
+$ exists target/license-reports/example-licenses.md
+$ exists target/license-reports/example-licenses.html
+$ exists target/license-reports/example-licenses.csv
+> check


### PR DESCRIPTION
Adds the ability to filter out unwanted dependencies from the report, this setting is particularly useful in multi sbt project builds particularly when using `dependsOn` (i.e. you want to filter out the inter `dependsOn` dependencies within the build, in pekko's case we may not want all of the `pekko-*` artifacts in our license report since those are the artifacts that pekko build is actually providing)