### PR TITLE
Update and apply scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,10 +1,26 @@
-version = 2.0.0
+version = 3.7.3
+runner.dialect = scala212
 maxColumn = 120
 project.git = true
 
 # http://docs.scala-lang.org/style/scaladoc.html recommends the JavaDoc style.
 # scala/scala is written that way too https://github.com/scala/scala/blob/v2.12.2/src/library/scala/Predef.scala
-docstrings = JavaDoc
+docstrings.style = Asterisk
 
 # This also seems more idiomatic to include whitespace in import x.{ yyy }
 spaces.inImportCurlyBraces = true
+
+align.tokens."+" = [
+  {
+    code   = "%"
+    owners = [
+      { regex = "Term.ApplyInfix" }
+    ]
+  },
+  {
+    code   = "%%"
+    owners = [
+      { regex = "Term.ApplyInfix" }
+    ]
+  }
+]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.5.0")

--- a/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
@@ -6,7 +6,7 @@ case class LicenseCategory(name: String, synonyms: Seq[String] = Nil) {
   def unapply(license: String): Boolean = {
     val names = name +: synonyms
     names exists { n =>
-      (license.toLowerCase contains n.toLowerCase)
+      license.toLowerCase contains n.toLowerCase
     }
   }
 
@@ -18,8 +18,8 @@ object LicenseCategory {
   object GPLClasspath extends LicenseCategory("GPL with Classpath Extension") {
     override def unapply(license: String): Boolean = {
       val name = license.toLowerCase
-      ((name.contains("gpl") || name.contains("general public license")) &&
-      name.contains("classpath"))
+      (name.contains("gpl") || name.contains("general public license")) &&
+      name.contains("classpath")
     }
   }
   val GPL = LicenseCategory("GPL", Seq("general public license"))

--- a/src/main/scala/sbtlicensereport/license/LicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseReport.scala
@@ -28,7 +28,7 @@ object LicenseReport {
     Using.fileWriter(java.nio.charset.Charset.defaultCharset, false)(file) { writer =>
       def println(msg: Any): Unit = {
         writer.write(msg.toString)
-        //writer.newLine()
+        // writer.newLine()
       }
       f(println _)
     }
@@ -39,15 +39,14 @@ object LicenseReport {
       config: LicenseReportConfiguration
   ): Unit = {
     import config._
-    val ordered = reportLicenses.filter(l => licenseFilter(l.license.category)) sortWith {
-      case (l, r) =>
-        if (l.license.category != r.license.category) l.license.category.name < r.license.category.name
+    val ordered = reportLicenses.filter(l => licenseFilter(l.license.category)) sortWith { case (l, r) =>
+      if (l.license.category != r.license.category) l.license.category.name < r.license.category.name
+      else {
+        if (l.license.name != r.license.name) l.license.name < r.license.name
         else {
-          if (l.license.name != r.license.name) l.license.name < r.license.name
-          else {
-            l.module.toString < r.module.toString
-          }
+          l.module.toString < r.module.toString
         }
+      }
     }
     // TODO - Make one of these for every configuration?
     for (language <- languages) {
@@ -93,8 +92,8 @@ object LicenseReport {
   }
 
   /**
-   * given a set of categories and an array of ivy-resolved licenses, pick the first one from our list, or
-   *  default to 'none specified'.
+   * given a set of categories and an array of ivy-resolved licenses, pick the first one from our list, or default to
+   * 'none specified'.
    */
   private def pickLicense(
       categories: Seq[LicenseCategory]
@@ -133,11 +132,10 @@ object LicenseReport {
         .getOrElse(Array(new org.apache.ivy.core.module.descriptor.License("none specified", "none specified")))
       homepage = Option
         .apply(desc.getHomePage)
-        .flatMap(
-          loc =>
-            nonFatalCatch[Option[URL]]
-              .withApply((_: Throwable) => Option.empty[URL])
-              .apply(Some(url(loc)))
+        .flatMap(loc =>
+          nonFatalCatch[Option[URL]]
+            .withApply((_: Throwable) => Option.empty[URL])
+            .apply(Some(url(loc)))
         )
       // TODO - grab configurations.
     } yield DepLicense(getModuleInfo(dep), pickLicense(categories)(licenses), homepage, filteredConfigs)

--- a/src/main/scala/sbtlicensereport/license/TargetLanguage.scala
+++ b/src/main/scala/sbtlicensereport/license/TargetLanguage.scala
@@ -2,7 +2,7 @@ package sbtlicensereport
 package license
 
 /**
- * Hooks for generating "rich" text documents.  Borrowed from scala/make-release-notes
+ * Hooks for generating "rich" text documents. Borrowed from scala/make-release-notes
  */
 sealed trait TargetLanguage {
   def documentStart(title: String, reportStyleRules: Option[String]): String
@@ -77,8 +77,8 @@ case object Html extends TargetLanguage {
     <tbody>"""
   def tableRow(firstColumn: String, secondColumn: String, thirdColumn: String, fourthColumn: String): String =
     s"""<tr><td>${firstColumn}&nbsp;</td><td>${secondColumn}&nbsp;</td><td>${thirdColumn}&nbsp;</td><td>${htmlEncode(
-      fourthColumn
-    )}</td></tr>"""
+        fourthColumn
+      )}</td></tr>"""
   def tableEnd: String = "</tbody></table>"
 
   def htmlEncode(s: String) = org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(s)

--- a/src/sbt-test/dumpLicenseReport/aggregate-report/example.sbt
+++ b/src/sbt-test/dumpLicenseReport/aggregate-report/example.sbt
@@ -2,34 +2,47 @@ name := "example"
 
 excludeDependencies in ThisBuild += "org.scala-lang"
 
-lazy val one = project.in(file("one")).settings(
-  List(
-    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.4",
-    libraryDependencies += "junit" % "junit" % "4.12" % "test"
+lazy val one = project
+  .in(file("one"))
+  .settings(
+    List(
+      libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.4",
+      libraryDependencies += "junit"                      % "junit"            % "4.12" % "test"
+    )
   )
-)
 
-lazy val two = project.in(file("two")).settings(
-  List(
-    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.6"
+lazy val two = project
+  .in(file("two"))
+  .settings(
+    List(
+      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.6"
+    )
   )
-)
 
 // Deliberately excluded from project root aggregate so we can test that it doesn't get included
 // in report
-lazy val three = project.in(file("three")).settings(
-  List(
-    libraryDependencies += "com.google.guava" % "guava" % "31.1-jre"
+lazy val three = project
+  .in(file("three"))
+  .settings(
+    List(
+      libraryDependencies += "com.google.guava" % "guava" % "31.1-jre"
+    )
   )
-)
 
-lazy val root = project.in(file(".")).aggregate(
-  one, two
-)
+lazy val root = project
+  .in(file("."))
+  .aggregate(
+    one,
+    two
+  )
 
 TaskKey[Unit]("check") := {
   val contents = sbt.IO.read(target.value / "license-reports" / "example-licenses.md")
-  if (!contents.contains("[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | [com.fasterxml.jackson.core # jackson-databind # 2.5.4](http://github.com/FasterXML/jackson)"))
+  if (
+    !contents.contains(
+      "[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | [com.fasterxml.jackson.core # jackson-databind # 2.5.4](http://github.com/FasterXML/jackson)"
+    )
+  )
     sys.error("Expected report to contain jackson-databind with Apache license: " + contents)
   if (!contents.contains("jackson-databind"))
     sys.error("Expected report to contain jackson-databind: " + contents)
@@ -37,7 +50,11 @@ TaskKey[Unit]("check") := {
     sys.error("Expected report to contain logback-classic:" + contents)
   if (contents.contains("guava"))
     sys.error("Expected report to NOT contain guava:" + contents)
-  if (!contents.contains("[Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html) | [junit # junit # 4.12](http://junit.org)"))
+  if (
+    !contents.contains(
+      "[Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html) | [junit # junit # 4.12](http://junit.org)"
+    )
+  )
     sys.error("Expected report to contain junit with EPL license: " + contents)
   // Test whether exclusions are included.
   if (contents.contains("scala-library"))

--- a/src/sbt-test/dumpLicenseReport/anyproject-report/example.sbt
+++ b/src/sbt-test/dumpLicenseReport/anyproject-report/example.sbt
@@ -2,28 +2,40 @@ name := "example"
 
 excludeDependencies in ThisBuild += "org.scala-lang"
 
-lazy val one = project.in(file("one")).settings(
-  List(
-    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.4",
-    libraryDependencies += "junit" % "junit" % "4.12" % "test"
+lazy val one = project
+  .in(file("one"))
+  .settings(
+    List(
+      libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.4",
+      libraryDependencies += "junit"                      % "junit"            % "4.12" % "test"
+    )
   )
-)
 
-lazy val two = project.in(file("two")).settings(
-  List(
-    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.6"
+lazy val two = project
+  .in(file("two"))
+  .settings(
+    List(
+      libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.6"
+    )
   )
-)
 
 TaskKey[Unit]("check") := {
   val contents = sbt.IO.read(target.value / "license-reports" / "example-licenses.md")
-  if (!contents.contains("[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | [com.fasterxml.jackson.core # jackson-databind # 2.5.4](http://github.com/FasterXML/jackson)"))
+  if (
+    !contents.contains(
+      "[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | [com.fasterxml.jackson.core # jackson-databind # 2.5.4](http://github.com/FasterXML/jackson)"
+    )
+  )
     sys.error("Expected report to contain jackson-databind with Apache license: " + contents)
   if (!contents.contains("jackson-databind"))
     sys.error("Expected report to contain jackson-databind: " + contents)
   if (!contents.contains("logback-classic"))
     sys.error("Expected report to contain logback-classic:" + contents)
-  if (!contents.contains("[Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html) | [junit # junit # 4.12](http://junit.org)"))
+  if (
+    !contents.contains(
+      "[Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html) | [junit # junit # 4.12](http://junit.org)"
+    )
+  )
     sys.error("Expected report to contain junit with EPL license: " + contents)
   // Test whether exclusions are included.
   if (contents.contains("scala-library"))

--- a/src/sbt-test/dumpLicenseReport/custom-report/example.sbt
+++ b/src/sbt-test/dumpLicenseReport/custom-report/example.sbt
@@ -16,11 +16,11 @@ licenseReportNotes := { case _ => "Default Notes" }
 licenseReportConfigurations +=
   LicenseReportConfiguration(
     "test-config",
-     Seq(Html),
-     language => language.header1("Testing the configuration"),
-     dep => Option("Default notes"),
-     category => category == LicenseCategory.BSD,
-     licenseReportDir.value
+    Seq(Html),
+    language => language.header1("Testing the configuration"),
+    dep => Option("Default notes"),
+    category => category == LicenseCategory.BSD,
+    licenseReportDir.value
   )
 
 val check = taskKey[Unit]("check the license report.")
@@ -37,6 +37,6 @@ check := {
       System.err.println("-- Report --")
       System.err.println(report)
       throw t
-  } 
+  }
   ()
 }

--- a/src/sbt-test/dumpLicenseReport/default-report/example.sbt
+++ b/src/sbt-test/dumpLicenseReport/default-report/example.sbt
@@ -1,17 +1,25 @@
 name := "example"
 
 libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.4"
-libraryDependencies += "junit"                      % "junit"            % "4.12"  % "test"
+libraryDependencies += "junit"                      % "junit"            % "4.12" % "test"
 
 excludeDependencies += "org.scala-lang"
 
 TaskKey[Unit]("check") := {
   val contents = sbt.IO.read(target.value / "license-reports" / "example-licenses.md")
-  if (!contents.contains("[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | [com.fasterxml.jackson.core # jackson-databind # 2.5.4](http://github.com/FasterXML/jackson)"))
+  if (
+    !contents.contains(
+      "[The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) | [com.fasterxml.jackson.core # jackson-databind # 2.5.4](http://github.com/FasterXML/jackson)"
+    )
+  )
     sys.error("Expected report to contain jackson-databind with Apache license: " + contents)
   if (!contents.contains("jackson-databind"))
     sys.error("Expected report to contain jackson-databind: " + contents)
-  if (!contents.contains("[Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html) | [junit # junit # 4.12](http://junit.org)"))
+  if (
+    !contents.contains(
+      "[Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html) | [junit # junit # 4.12](http://junit.org)"
+    )
+  )
     sys.error("Expected report to contain junit with EPL license: " + contents)
   // Test whether exclusions are included.
   if (contents.contains("scala-library"))

--- a/src/sbt-test/dumpLicenseReport/dep-exclusions-report/example.sbt
+++ b/src/sbt-test/dumpLicenseReport/dep-exclusions-report/example.sbt
@@ -1,12 +1,12 @@
 name := "example"
 
 libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.4"
-libraryDependencies += "junit"                      % "junit"            % "4.12"  % "test"
+libraryDependencies += "junit"                      % "junit"            % "4.12" % "test"
 
 excludeDependencies += "org.scala-lang"
 
-licenseDepExclusions := {
-  case DepModuleInfo("junit", _, _) => true
+licenseDepExclusions := { case DepModuleInfo("junit", _, _) =>
+  true
 }
 
 TaskKey[Unit]("check") := {

--- a/test-project/build.sbt
+++ b/test-project/build.sbt
@@ -4,8 +4,8 @@ import com.typesafe.sbt.SbtLicenseReport.autoImport._
 libraryDependencies += "com.typesafe.play" %% "play" % "2.2.2"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.slick" %% "slick" % "2.0.1",
-  "org.slf4j" % "slf4j-nop" % "1.6.4"
+  "com.typesafe.slick" %% "slick"     % "2.0.1",
+  "org.slf4j"           % "slf4j-nop" % "1.6.4"
 )
 
 scalaVersion := "2.10.4"
@@ -14,16 +14,17 @@ licenseReportNotes := licenseReportNotes.value orElse {
   case DepModuleInfo(org, _, _) if org contains "com.typesafe" => "From Typesafe Reactive Platform."
 }
 
-licenseOverrides := licenseOverrides.value orElse {
-  case DepModuleInfo("com.typesafe.play", _, _) => LicenseInfo(LicenseCategory.Apache, "Apache 2", "http://www.apache.org/licenses/LICENSE-2.0")
+licenseOverrides := licenseOverrides.value orElse { case DepModuleInfo("com.typesafe.play", _, _) =>
+  LicenseInfo(LicenseCategory.Apache, "Apache 2", "http://www.apache.org/licenses/LICENSE-2.0")
 }
 
 // Test adding custom reports.
 licenseReportConfigurations +=
   LicenseReportConfiguration(
-   "test-config",
-   Seq(MarkDown),
-   language => language.header1("Testing the configuration"),
-   dep => Option("Default notes"),
-   category => category == LicenseCategory.BSD,
-   licenseReportDir.value)
+    "test-config",
+    Seq(MarkDown),
+    language => language.header1("Testing the configuration"),
+    dep => Option("Default notes"),
+    category => category == LicenseCategory.BSD,
+    licenseReportDir.value
+  )

--- a/test-project/project/plugins.sbt
+++ b/test-project/project/plugins.sbt
@@ -1,3 +1,3 @@
-lazy val root = Project("plugins", file(".")) dependsOn(packager)
+lazy val root = Project("plugins", file(".")) dependsOn (packager)
 
 lazy val packager = RootProject(file("..").getAbsoluteFile.toURI)


### PR DESCRIPTION
Updates scalafmt version to latest as well as applying it. While the diff is quite big, I deliberately made a decision to make the `.scalafmt.conf` file to be simple like the original. It is possible to reduce the diff but it requires a lot of complex/bespoke options due to how scalafmt has massively changed from v2 to v3 (if you want to get an idea of what I mean, have a look at https://github.com/mdedetrich/incubator-pekko/blob/main/.scalafmt.conf which as you can see ended up adding a massive explosion of options to try and minimize the diff).

If you want me to I can spend time modifying `.scalafmt.conf` to match the current style as much as possible but it will take some time and I presume its not really a big deal for this project.