### PR TITLE
Add .git-blame-ignore-revs containing scalafmt commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# scalafmt
+0f3b261dccea0509bc89d9cf9adcff49089748f6
+fef901b315a1dc9d8c65fcd5cabf4df5e526d3da


### PR DESCRIPTION
This allows developers to ignore scalafmt commits when doing git blame