### PR TITLE
Use scalafmt github workflow check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,3 @@ jobs:
           cache: 'sbt'
 
       - run: sbt -v +scripted
-      - name: Scalafmt
-        shell: bash
-        run: sbt -v clean scalafmtSbtCheck scalafmtCheckAll

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,24 @@
+name: Scalafmt
+
+permissions: {}
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v2
+        with:
+          version: '3.7.3'
+          arguments: '--list --mode diff-ref=origin/main'


### PR DESCRIPTION
This replaces the scalafmt check via sbt with scala-native in a github workflow check. While this may be a bit opinionated, I find this method of checking if the code is formatted more developer friendly. Specifically in the case of this project having the check in its own workflow means it will work concurrently to the main compile/test and it will still run even if the code fails to compile. The check is also incredibly fast since it uses scalafmt-native (as you can see it only takes ~5 seconds).

After this PR is merged you can add this check to Settings -> Branches -> Main -> Require status checks to pass before merging  and add the scalafmt check to the list to prevent PR's from being merged if code isn't formatted correctly.