### PR TITLE
Add support for additional columns

### DIFF
--- a/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
@@ -16,7 +16,9 @@ object SbtLicenseReport extends AutoPlugin {
     type TargetLanguage = sbtlicensereport.license.TargetLanguage
     type LicenseReportConfiguration = sbtlicensereport.license.LicenseReportConfiguration
     type DepModuleInfo = sbtlicensereport.license.DepModuleInfo
+    type Column = sbtlicensereport.license.Column
     val DepModuleInfo = sbtlicensereport.license.DepModuleInfo
+    val Column = sbtlicensereport.license.Column
     def LicenseReportConfiguration = sbtlicensereport.license.LicenseReportConfiguration
     def Html = sbtlicensereport.license.Html
     def MarkDown = sbtlicensereport.license.MarkDown
@@ -34,6 +36,8 @@ object SbtLicenseReport extends AutoPlugin {
     val dumpLicenseReportAnyProject = taskKey[File](
       "Dumps a report file against all projects of the license report (using the target language) and combines it into a single file."
     )
+    val licenseReportColumns =
+      settingKey[Seq[Column]]("Additional columns to be added to the final report")
     val licenseReportDir = settingKey[File]("The location where we'll write the license reports.")
     val licenseReportStyleRules = settingKey[Option[String]]("The style rules for license report styling.")
     val licenseReportTitle = settingKey[String]("The name of the license report.")
@@ -75,12 +79,14 @@ object SbtLicenseReport extends AutoPlugin {
         val ignore = update.value
         val overrides = licenseOverrides.value.lift
         val depExclusions = licenseDepExclusions.value.lift
+        val originatingModule = DepModuleInfo(organization.value, name.value, version.value)
         license.LicenseReport.makeReport(
           ivyModule.value,
           licenseConfigurations.value,
           licenseSelection.value,
           overrides,
           depExclusions,
+          originatingModule,
           streams.value.log
         )
       },
@@ -101,7 +107,8 @@ object SbtLicenseReport extends AutoPlugin {
           notesLookup,
           licenseFilter.value,
           dir,
-          styleRules
+          styleRules,
+          licenseReportColumns.value
         )
         Seq(config)
       },
@@ -137,6 +144,7 @@ object SbtLicenseReport extends AutoPlugin {
     licenseDepExclusions := PartialFunction.empty,
     licenseFilter := TypeFunctions.const(true),
     licenseReportStyleRules := None,
-    licenseReportTypes := Seq(MarkDown, Html, Csv)
+    licenseReportTypes := Seq(MarkDown, Html, Csv),
+    licenseReportColumns := Seq(Column.Category, Column.License, Column.Dependency)
   )
 }

--- a/src/main/scala/sbtlicensereport/license/Column.scala
+++ b/src/main/scala/sbtlicensereport/license/Column.scala
@@ -1,0 +1,48 @@
+package sbtlicensereport.license
+
+trait Column {
+  def columnName: String
+
+  def render(depLicense: DepLicense, language: TargetLanguage): String
+}
+
+object Column {
+  case object Category extends Column {
+    override val columnName: String = "Category"
+
+    override def render(depLicense: DepLicense, language: TargetLanguage): String =
+      depLicense.license.category.name
+  }
+
+  case object License extends Column {
+    override val columnName: String = "License"
+
+    override def render(depLicense: DepLicense, language: TargetLanguage): String =
+      language.createHyperLink(depLicense.license.url, depLicense.license.name)
+  }
+
+  case object Dependency extends Column {
+    override val columnName: String = "Dependency"
+
+    override def render(depLicense: DepLicense, language: TargetLanguage): String =
+      depLicense.homepage match {
+        case None      => depLicense.module.toString
+        case Some(url) => language.createHyperLink(url.toExternalForm, depLicense.module.toString)
+      }
+  }
+
+  case object Configuration extends Column {
+    override val columnName: String = "Maven/Ivy Configurations"
+
+    override def render(depLicense: DepLicense, language: TargetLanguage): String = {
+      depLicense.configs.mkString(",")
+    }
+  }
+
+  case object OriginatingArtifactName extends Column {
+    override val columnName: String = "Originating Artifact"
+
+    override def render(depLicense: DepLicense, language: TargetLanguage): String =
+      depLicense.originatingModule.name
+  }
+}

--- a/src/main/scala/sbtlicensereport/license/LicenseReportConfiguration.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseReportConfiguration.scala
@@ -10,5 +10,6 @@ case class LicenseReportConfiguration(
     notes: DepModuleInfo => Option[String],
     licenseFilter: LicenseCategory => Boolean,
     reportDir: File,
-    reportStyleRules: Option[String] = None
+    reportStyleRules: Option[String] = None,
+    licenseReportColumns: Seq[Column]
 )

--- a/src/sbt-test/dumpLicenseReport/custom-report/example.sbt
+++ b/src/sbt-test/dumpLicenseReport/custom-report/example.sbt
@@ -20,7 +20,9 @@ licenseReportConfigurations +=
     language => language.header1("Testing the configuration"),
     dep => Option("Default notes"),
     category => category == LicenseCategory.BSD,
-    licenseReportDir.value
+    licenseReportDir.value,
+    None,
+    Seq(Column.Category, Column.License, Column.Dependency)
   )
 
 val check = taskKey[Unit]("check the license report.")


### PR DESCRIPTION
This PR gives the ability of sbt-license-report to both redefine the ordering of the current columns as well as the ability to add custom columns. This is primarily done by changing the hardcoding of `firstColumn`/`secondColumn`/`thirdColumn` into a generic list of columns which is exposed by the `licenseReportColumns` key. Additional types of columns have also been added which can be deemed handy (i.e. `Configuration`/`OriginatingArtifactName`) but note that the behaviour of the generated reports remains the same since the default value of `licenseReportColumns` is `Seq(Column.Category, Column.License, Column.Dependency)`.

One additional thing to note is that this project has a special column called `Notes` which is user defined by `licenseReportNotes` key. Due to the fact that this column is just arbitrary notes its included as its own variable/parameter rather than just being included in the generic list (i.e. `def tableHeader(notes: String, columns: String*)` is an example). Due to the usage of varags in the project this means that `notes` parameter has been pushed to the leftmost arg.

Finally I haven't add tests to this PR, this is a result of me trying to add unit tests to check the rendered content however implementing this is more complicated than anticipated due to the `def dumpLicenseReport(reportLicenses: Seq[DepLicense], config: LicenseReportConfiguration)` internally using a writer so to make unit tests I would have to split this out. I did check to make sure there was no regressions in rendering, both by hand checking and evaluating the relevant Scala code in the repl but if requested I can either provide the tests in this PR or in a follow up PR. I have also tested this PR against pekko to see that everything works as expected.