### PR TITLE
Add license check

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In either case the results will be merged into a single report file in a format 
 
 If you want to check that only certain licenses are used in a project, you can use
 
-     > checkLicenses
+     > licenseCheck
 
 This ensures all licenses fall into one of the categories given by `licenseCheckAllow` which defaults
 to a set of commonly allowed [OSS licenses](./src/main/scala/sbtlicensereport/SbtLicenseReport.scala#L173).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ If you want to check that only certain licenses are used in a project, you can u
 
 This ensures all licenses fall into one of the categories given by `licenseCheckAllow` which defaults
 to a set of commonly allowed [OSS licenses](./src/main/scala/sbtlicensereport/SbtLicenseReport.scala#L173).
-Analogous to the variants of `dumpLicenseReport`, `checkLicensesAggregate` and `checkLicensesAnyProject` exist.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ If you happen to be using a multi project sbt build, you can instead use `dumpLi
 from `aggregate` on the root project) or `dumpLicenseReportAnyProject` (which collects the results for all projects in the sbt build).
 In either case the results will be merged into a single report file in a format that mirrors `dumpLicenseReport`.
 
+### Check licenses
+
+If you want to check that only certain licenses are used in a project, you can use
+
+     > checkLicenses
+
+This ensures all licenses fall into one of the categories given by `licenseCheckAllow` which defaults
+to a set of commonly allowed [OSS licenses](./src/main/scala/sbtlicensereport/SbtLicenseReport.scala#L173).
+Analogous to the variants of `dumpLicenseReport`, `checkLicensesAggregate` and `checkLicensesAnyProject` exist.
+
 ## Configuration
 
 The license report plugin can be configured to dump any number of reports, but the default report

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.0-M1
+sbt.version=1.9.3

--- a/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
@@ -37,10 +37,6 @@ object SbtLicenseReport extends AutoPlugin {
       "Dumps a report file against all projects of the license report (using the target language) and combines it into a single file."
     )
     val checkLicenses = taskKey[Unit]("Checks that all licenses are allowed. Fails if other licenses are found.")
-    val checkLicensesAggregate =
-      taskKey[Unit]("Checks that all licenses are allowed in a project aggregate. Fails if other licenses are found.")
-    val checkLicensesAnyProject =
-      taskKey[Unit]("Checks that all licenses are allowed in any project. Fails if other licenses are found.")
     val licenseReportColumns =
       settingKey[Seq[Column]]("Additional columns to be added to the final report")
     val licenseReportDir = settingKey[File]("The location where we'll write the license reports.")
@@ -144,18 +140,6 @@ object SbtLicenseReport extends AutoPlugin {
         val report = updateLicenses.value
         val allowed = licenseCheckAllow.value
         LicenseReport.checkLicenses(report.licenses, allowed, log)
-      },
-      checkLicensesAggregate := {
-        val log = streams.value.log
-        val reports = aggregateUpdateLicenses.value
-        val allowed = licenseCheckAllow.value
-        LicenseReport.checkLicenses(reports.flatMap(_.licenses), allowed, log)
-      },
-      checkLicensesAnyProject := {
-        val log = streams.value.log
-        val reports = anyProjectUpdateLicenses.value
-        val allowed = licenseCheckAllow.value
-        LicenseReport.checkLicenses(reports.flatMap(_.licenses), allowed, log)
       }
     )
 

--- a/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
@@ -36,7 +36,7 @@ object SbtLicenseReport extends AutoPlugin {
     val dumpLicenseReportAnyProject = taskKey[File](
       "Dumps a report file against all projects of the license report (using the target language) and combines it into a single file."
     )
-    val checkLicenses = taskKey[Unit]("Checks that all licenses are allowed. Fails if other licenses are found.")
+    val licenseCheck = taskKey[Unit]("Checks that all licenses are allowed. Fails if other licenses are found.")
     val licenseReportColumns =
       settingKey[Seq[Column]]("Additional columns to be added to the final report")
     val licenseReportDir = settingKey[File]("The location where we'll write the license reports.")
@@ -135,7 +135,7 @@ object SbtLicenseReport extends AutoPlugin {
           LicenseReport.dumpLicenseReport(reports.flatMap(_.licenses), config)
         dir
       },
-      checkLicenses := {
+      licenseCheck := {
         val log = streams.value.log
         val report = updateLicenses.value
         val allowed = licenseCheckAllow.value

--- a/src/main/scala/sbtlicensereport/license/LicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseReport.scala
@@ -87,8 +87,13 @@ object LicenseReport {
       case dep if !allowed.contains(dep.license.category) => dep
     }
     if (violators.nonEmpty) {
-      log.error("Found non-allowed licenses among the dependencies:")
-      violators.sorted.foreach(viol => log.error(s"${viol.license.category.name}: ${viol.module.toString}"))
+      log.error(
+        violators.sorted
+          .map(v => (v.license, v.module))
+          .distinct
+          .map { case (license, module) => s"${license.category.name}: ${module.toString}" }
+          .mkString("Found non-allowed licenses among the dependencies:\n", "\n", "")
+      )
       throw new sbt.MessageOnlyException(s"Found non-allowed licenses!")
     } else {
       log.info("Found only allowed licenses among the dependencies!")

--- a/src/main/scala/sbtlicensereport/license/LicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseReport.scala
@@ -21,6 +21,18 @@ case class DepLicense(
     s"$module ${homepage.map(url => s" from $url")} on $license in ${configs.mkString("(", ",", ")")}"
 }
 
+object DepLicense {
+  implicit val ordering: Ordering[DepLicense] = Ordering.fromLessThan { case (l, r) =>
+    if (l.license.category != r.license.category) l.license.category.name < r.license.category.name
+    else {
+      if (l.license.name != r.license.name) l.license.name < r.license.name
+      else {
+        l.module.toString < r.module.toString
+      }
+    }
+  }
+}
+
 case class LicenseReport(licenses: Seq[DepLicense], orig: ResolveReport) {
   override def toString = s"""|## License Report ##
                               |${licenses.mkString("\t", "\n\t", "\n")}
@@ -45,15 +57,7 @@ object LicenseReport {
       config: LicenseReportConfiguration
   ): Unit = {
     import config._
-    val ordered = reportLicenses.filter(l => licenseFilter(l.license.category)) sortWith { case (l, r) =>
-      if (l.license.category != r.license.category) l.license.category.name < r.license.category.name
-      else {
-        if (l.license.name != r.license.name) l.license.name < r.license.name
-        else {
-          l.module.toString < r.module.toString
-        }
-      }
-    }
+    val ordered = reportLicenses.filter(l => licenseFilter(l.license.category)).sorted
     // TODO - Make one of these for every configuration?
     for (language <- languages) {
       val reportFile = new File(config.reportDir, s"${title}.${language.ext}")
@@ -75,6 +79,19 @@ object LicenseReport {
         print(language.tableEnd)
         print(language.documentEnd)
       }
+    }
+  }
+
+  def checkLicenses(reportLicenses: Seq[DepLicense], allowed: Seq[LicenseCategory], log: Logger): Unit = {
+    val violators = reportLicenses.collect {
+      case dep if !allowed.contains(dep.license.category) => dep
+    }
+    if (violators.nonEmpty) {
+      log.error("Found non-allowed licenses among the dependencies:")
+      violators.sorted.foreach(viol => log.error(s"${viol.license.category.name}: ${viol.module.toString}"))
+      throw new sbt.MessageOnlyException(s"Found non-allowed licenses!")
+    } else {
+      log.info("Found only allowed licenses among the dependencies!")
     }
   }
 


### PR DESCRIPTION
Add sbt tasks that allow to check whether any dependency uses a license that is not within an allowed set of license categories. This is helpful for corporate environments where only certain licenses may be used. The tasks behave similar to check tasks of other set plugins, for example `scalafmtCheckAll`.