### PR TITLE
Add Unicode license (ICU)

### DIFF
--- a/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
@@ -162,7 +162,8 @@ object SbtLicenseReport extends AutoPlugin {
       LicenseCategory.EPL,
       LicenseCategory.MIT,
       LicenseCategory.Mozilla,
-      LicenseCategory.PublicDomain
+      LicenseCategory.PublicDomain,
+      LicenseCategory.Unicode
     )
   )
 }

--- a/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
@@ -31,6 +31,7 @@ object LicenseCategory {
   val EPL = LicenseCategory("EPL", Seq("Eclipse Public License"))
   val CDDL = LicenseCategory("CDDL", Seq("Common Development and Distribution"))
   val BouncyCastle = LicenseCategory("Bouncy Castle License", Seq("Bouncy Castle"))
+  val Unicode = LicenseCategory("Unicode/ICU License", Seq("Unicode", "ICU"))
   val Proprietary = LicenseCategory("Proprietary")
   val NoneSpecified = LicenseCategory("none specified")
   val Unrecognized = LicenseCategory("unrecognized")
@@ -50,6 +51,7 @@ object LicenseCategory {
       EPL,
       CDDL,
       BouncyCastle,
+      Unicode,
       Proprietary
     )
 


### PR DESCRIPTION
As icu4j and alike are popular libraries, it seems worth having the license recognized properly.