### PR TITLE
Add APL2 license alias

### DIFF
--- a/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
@@ -13,7 +13,7 @@ case class LicenseCategory(name: String, synonyms: Seq[String] = Nil) {
 }
 object LicenseCategory {
   val BSD = LicenseCategory("BSD")
-  val Apache = LicenseCategory("Apache", Seq("asf", "ALv2"))
+  val Apache = LicenseCategory("Apache", Seq("asf", "ALv2", "APL2"))
   val LGPL = LicenseCategory("LGPL", Seq("lesser general public license"))
   object GPLClasspath extends LicenseCategory("GPL with Classpath Extension") {
     override def unapply(license: String): Boolean = {


### PR DESCRIPTION
Another alias for Apache 2 license

![image](https://github.com/sbt/sbt-license-report/assets/2337269/9bda53a3-8d49-4f3c-92d1-cf1a671affd3)
