### PR TITLE
Add Go as BSD license

### DIFF
--- a/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
@@ -12,7 +12,7 @@ case class LicenseCategory(name: String, synonyms: Seq[String] = Nil) {
 
 }
 object LicenseCategory {
-  val BSD = LicenseCategory("BSD")
+  val BSD = LicenseCategory("BSD", Seq("Go"))
   val Apache = LicenseCategory("Apache", Seq("asf", "ALv2", "APL2"))
   val LGPL = LicenseCategory("LGPL", Seq("lesser general public license"))
   object GPLClasspath extends LicenseCategory("GPL with Classpath Extension") {

--- a/src/main/scala/sbtlicensereport/license/LicenseInfo.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseInfo.scala
@@ -59,4 +59,6 @@ object LicenseInfo {
     LicenseInfo(LicenseCategory.BouncyCastle, "Bouncy Castle Licence", "https://www.bouncycastle.org/license.html")
   val JSON =
     LicenseInfo(LicenseCategory.JSON, "The JSON License", "https://json.org/license.html")
+  val Go =
+    LicenseInfo(LicenseCategory.BSD, "The Go License", "https://golang.org/LICENSE")
 }


### PR DESCRIPTION
![image](https://github.com/sbt/sbt-license-report/assets/2337269/3e61c013-784e-482a-9c8d-6042154e185f)

This is another BSD based license, you can verify this by reading the text of https://go.dev/LICENSE (aside from the copyright placeholders which has been set to Google the text is the same).