### PR TITLE
Add Unicode License Info

### DIFF
--- a/src/main/scala/sbtlicensereport/license/LicenseInfo.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseInfo.scala
@@ -66,4 +66,10 @@ object LicenseInfo {
     "IBM International Program License Agreement",
     "https://www.ibm.com/support/customer/csol/terms/?id=i125-3301&lc=en#detail-document"
   )
+  val Unicode =
+    LicenseInfo(
+      LicenseCategory.Unicode,
+      "Unicode/ICU License",
+      "https://raw.githubusercontent.com/unicode-org/icu/master/LICENSE"
+    )
 }


### PR DESCRIPTION
The `LicenseInfo` was forgotten to be added in https://github.com/sbt/sbt-license-report/pull/75