### PR TITLE
Fix CDDL + GPL with classpath LicenseCategory

### DIFF
--- a/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
@@ -22,6 +22,14 @@ object LicenseCategory {
       name.contains("classpath")
     }
   }
+  object CDDLPlusGPLClasspath extends LicenseCategory("CDDL + GPLv2 with classpath exception") {
+    override def unapply(license: String): Boolean = {
+      val name = license.toLowerCase
+      (name.contains("gpl") || name.contains("general public license")) &&
+      (name.contains("cddl") || name.contains("common development and distribution license")) &&
+      name.contains("classpath")
+    }
+  }
   val GPL = LicenseCategory("GPL", Seq("general public license"))
   val Mozilla = LicenseCategory("Mozilla", Seq("mpl"))
   val MIT = LicenseCategory("MIT")

--- a/src/main/scala/sbtlicensereport/license/LicenseInfo.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseInfo.scala
@@ -36,9 +36,9 @@ object LicenseInfo {
     "http://opensource.org/licenses/CDDL-1.0"
   )
   val CDDL_GPL = LicenseInfo(
-    LicenseCategory.CDDL,
-    "CDDL + GPLv2 License",
-    "https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html"
+    LicenseCategory.CDDLPlusGPLClasspath,
+    "CDDL + GPLv2 with classpath exception",
+    "https://oss.oracle.com/licenses/CDDL+GPL-1.1"
   )
   val APACHE2 = LicenseInfo(
     LicenseCategory.Apache,


### PR DESCRIPTION
This fixes an existing license. For starters the `LicenseCategory` its currently using is incorrect/misleading since it just points to `CDDL` instead of `CDDL + GPL with classpath exception`. Furthermore the current `"CDDL + GPLv2 License"` name is missing the "classpath exception" part, this missing of "classpath exception" is likely an oversight since this is a very bespoke license that is used for JVM `javax`/`glassfish` libraries (and all of these libraries have the classpath exception since its on the JVM). And finally the URI that `https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html` points to isn't even loading so this has been fixed.

If you want an example of a recently released library that has such a license look at `<licenses>` in https://repo1.maven.org/maven2/javax/servlet/javax.servlet-api/4.0.1/javax.servlet-api-4.0.1.pom, the data for this PR was taken from that.