### PR TITLE
Use DependencyResolver instead of IvySbt#Module directly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,15 @@
 lazy val lang3 = "org.apache.commons" % "commons-lang3" % "3.12.0"
 lazy val repoSlug = "sbt/sbt-license-report"
 
-crossScalaVersions := Seq("2.12.17", "2.10.7")
+val scala212 = "2.12.18"
+
+scalaVersion := scala212
+crossScalaVersions := Seq(scala212)
 organization := "com.github.sbt"
 name := "sbt-license-report"
 enablePlugins(SbtPlugin)
 libraryDependencies += lang3
 scriptedLaunchOpts += s"-Dplugin.version=${version.value}"
-pluginCrossBuild / sbtVersion := {
-  scalaBinaryVersion.value match {
-    case "2.10" => "0.13.18"
-    case "2.12" => "1.2.8" // set minimum sbt version
-  }
-}
 
 // publishing info
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))

--- a/src/main/scala-2.10/sbtlicensereport/SbtCompat.scala
+++ b/src/main/scala-2.10/sbtlicensereport/SbtCompat.scala
@@ -1,3 +1,0 @@
-package sbtlicensereport
-
-object SbtCompat

--- a/src/main/scala-2.12/sbtlicensereport/SbtCompat.scala
+++ b/src/main/scala-2.12/sbtlicensereport/SbtCompat.scala
@@ -1,8 +1,0 @@
-package sbtlicensereport
-
-object SbtCompat {
-  val Using = sbt.io.Using
-  val IvyRetrieve = sbt.internal.librarymanagement.IvyRetrieve
-  type IvySbt = sbt.internal.librarymanagement.IvySbt
-  type ResolveException = sbt.librarymanagement.ResolveException
-}

--- a/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
@@ -1,6 +1,7 @@
 package sbtlicensereport
 
 import sbt._
+import sbt.librarymanagement.ivy.IvyDependencyResolution
 import Keys._
 import license._
 
@@ -87,6 +88,7 @@ object SbtLicenseReport extends AutoPlugin {
         val originatingModule = DepModuleInfo(organization.value, name.value, version.value)
         license.LicenseReport.makeReport(
           ivyModule.value,
+          IvyDependencyResolution(ivyConfiguration.value),
           licenseConfigurations.value,
           licenseSelection.value,
           overrides,


### PR DESCRIPTION
So this PR is the result of me going down a giant rabbit hole. The original improvement I was trying to do is replacing the usage of `Ivy#Module` because I was experiencing https://github.com/sbt/sbt/issues/3618 and the workaround at https://github.com/sbt/sbt/issues/3618#issuecomment-424924293 for some reason didn't work (I guess `sys.props` was not being passed to sbt plugins due to classloader isolation???).

So after wasting a stupid amount of time figuring out if I could somehow pass the `packaging.type` manually into Ivy, I just figured why not just entirely replace `IvySbt#Module` with sbt's `update` task, that way we can also benefit from Coursier's faster dependency resolution (little tidbit, but sbt-license-report can end up taking ages in some cases due to Ivy). Then this is where the rabbit hole began, I ended up hitting https://github.com/coursier/coursier/issues/1790 (tl;dr version, Coursier doesn't properly grab the license information when using `Ivy#Module` as a module). IvySbt#Module also needs to be used because certain dependencies don't hold the license info in `pom.xml` (see https://discord.com/channels/632150470000902164/922600050989875282/1151492070373085306).

So rather than using `update` I instead opted for `IvyDependencyResolver`. While it doesn't go the full way of just using `update` to get all of the dependencies and their respective licenses, the data structures returned by both `DependencyResolution.update` and sbt's `update` task are the same (i.e. `UpdateReport`) so once that coursier issue is solved a future PR to use `update` will be trivial.

The PR also drops support for SBT 0.13.x because its ancient and `DependencyResolution` doesn't exist there.