### PR TITLE
Remove hard-coded scalafmt version

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,5 +20,4 @@ jobs:
       - name: Check project is formatted
         uses: jrouly/scalafmt-native-action@v3
         with:
-          version: '3.7.3'
           arguments: '--list --mode diff-ref=origin/main'


### PR DESCRIPTION
Since `scalafmt-native-action v3` the scalafmt version will be picked up from the `.scalafmt.conf` file.

see: https://github.com/jrouly/scalafmt-native-action/releases/tag/v3