### PR TITLE
Pin Scala 2.12 version for Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
+]


### PR DESCRIPTION
So that we don't get PR's like this https://github.com/sbt/sbt-license-report/pull/97