### PR TITLE
add Locale param for `toLowerCase`

### DIFF
--- a/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
@@ -1,12 +1,14 @@
 package sbtlicensereport
 package license
 
+import java.util.Locale
+
 // TODO - What do we mean by viral?
 case class LicenseCategory(name: String, synonyms: Seq[String] = Nil) {
   def unapply(license: String): Boolean = {
     val names = name +: synonyms
     names exists { n =>
-      license.toLowerCase contains n.toLowerCase
+      license.toLowerCase(Locale.ROOT) contains n.toLowerCase(Locale.ROOT)
     }
   }
 
@@ -17,14 +19,14 @@ object LicenseCategory {
   val LGPL = LicenseCategory("LGPL", Seq("lesser general public license"))
   object GPLClasspath extends LicenseCategory("GPL with Classpath Extension") {
     override def unapply(license: String): Boolean = {
-      val name = license.toLowerCase
+      val name = license.toLowerCase(Locale.ROOT)
       (name.contains("gpl") || name.contains("general public license")) &&
       name.contains("classpath")
     }
   }
   object CDDLPlusGPLClasspath extends LicenseCategory("CDDL + GPLv2 with classpath exception") {
     override def unapply(license: String): Boolean = {
-      val name = license.toLowerCase
+      val name = license.toLowerCase(Locale.ROOT)
       (name.contains("gpl") || name.contains("general public license")) &&
       (name.contains("cddl") || name.contains("common development and distribution license")) &&
       name.contains("classpath")


### PR DESCRIPTION
https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#toUpperCase--

> Note: This method is locale sensitive, and may produce unexpected results if used for strings that are intended to be interpreted locale independently. Examples are programming language identifiers, protocol keys, and HTML tags. For instance, "title".toUpperCase() in a Turkish locale returns "T\u0130TLE", where '\u0130' is the LATIN CAPITAL LETTER I WITH DOT ABOVE character. To obtain correct results for locale insensitive strings, use toUpperCase(Locale.ROOT).