### PR TITLE
Use 'update' instead of ivy resolution

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.0

--- a/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/SbtLicenseReport.scala
@@ -82,13 +82,11 @@ object SbtLicenseReport extends AutoPlugin {
     Seq(
       licenseReportTitle := s"${normalizedName.value}-licenses",
       updateLicenses := {
-        val ignore = update.value
         val overrides = licenseOverrides.value.lift
         val depExclusions = licenseDepExclusions.value.lift
         val originatingModule = DepModuleInfo(organization.value, name.value, version.value)
         license.LicenseReport.makeReport(
-          ivyModule.value,
-          IvyDependencyResolution(ivyConfiguration.value),
+          update.value,
           licenseConfigurations.value,
           licenseSelection.value,
           overrides,


### PR DESCRIPTION
Reproduces #87

This is now blocked on:
* [x] https://github.com/coursier/sbt-coursier/pull/507 
* [x] the next post-2.1.4 release of sbt-coursier / lm-coursier-shaded https://github.com/coursier/sbt-coursier/releases/tag/v2.1.5
* [x] sbt upgrading to that post-2.1.4 release https://github.com/sbt/sbt/commit/126846f88c7a8e7ae962ba6edcb915a93906dc6f
* [ ] a release of that sbt version