### PR TITLE
Add CDDLPlusGPLClasspath to LicenseCategory.all

### DIFF
--- a/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseCategory.scala
@@ -56,6 +56,7 @@ object LicenseCategory {
       BSD,
       Apache,
       LGPL,
+      CDDLPlusGPLClasspath,
       GPLClasspath,
       GPL,
       EPL,


### PR DESCRIPTION
Because this object was missing from `LicenseCategory.all` dependencies with that license were not parsed correctly.

As an aside, is there an explicit policy for what licenses can be included in the default allowlist? It seems most weak copyleft licenses are not included with the exception of EPL and Mozilla. I personally can't think of a usecase where simply pulling a weak copyleft dependency would be problematic.