### PR TITLE
Fix filtering of licenseConfigurations

### DIFF
--- a/src/main/scala/sbtlicensereport/license/LicenseReport.scala
+++ b/src/main/scala/sbtlicensereport/license/LicenseReport.scala
@@ -211,12 +211,13 @@ object LicenseReport {
 
   private def getLicenses(
       report: UpdateReport,
-      configs: Set[String] = Set.empty,
-      categories: Seq[LicenseCategory] = LicenseCategory.all,
+      configs: Set[String],
+      categories: Seq[LicenseCategory],
       originatingModule: DepModuleInfo
   ): Seq[DepLicense] = {
+    val relevantConfigurations = report.configurations.filter(c => configs.contains(c.configuration.name))
     for {
-      dep <- allModuleReports(report.configurations)
+      dep <- allModuleReports(relevantConfigurations)
       report <- pickLicenseForDep(dep, configs, categories, originatingModule)
     } yield report
   }


### PR DESCRIPTION
With the changes of #86, the filtering of configurations broke and test dependencies got reported even though `licenseConfigurations` was set to `Set("compile")`. This seems due to the fact that the resolved Ivy deps do not properly mirror the configurations the dependency was defined for. By selecting the configurations from the report early on, we restore the filtering.

FYI @mdedetrich 