### PR TITLE
Fix licensed libraries without URL classification

### DIFF
--- a/src/sbt-test/dumpLicenseReport/empty-url-report/example.sbt
+++ b/src/sbt-test/dumpLicenseReport/empty-url-report/example.sbt
@@ -1,0 +1,25 @@
+name := "example"
+
+val webJarsOrg = "org.webjars"
+val swaggerUiArtifact = "swagger-ui"
+val swaggerUiVersion = "5.30.2"
+libraryDependencies += webJarsOrg % swaggerUiArtifact % swaggerUiVersion
+
+excludeDependencies += "org.scala-lang"
+
+TaskKey[Unit]("check") := {
+  val contents = sbt.IO.read(target.value / "license-reports" / "example-licenses.md")
+
+  if (
+    !contents.contains(
+      s"[Apache-2.0]() | [$webJarsOrg # $swaggerUiArtifact # $swaggerUiVersion](https://www.webjars.org)"
+    )
+  )
+    sys.error(s"Expected report to contain $swaggerUiArtifact with Apache license: " + contents)
+  if (!contents.contains(swaggerUiArtifact))
+    sys.error(s"Expected report to contain $swaggerUiArtifact: " + contents)
+
+  // Test whether exclusions are included.
+  if (contents.contains("scala-library"))
+    sys.error("Expected report to NOT contain scala-library: " + contents)
+}

--- a/src/sbt-test/dumpLicenseReport/empty-url-report/project/plugins.sbt
+++ b/src/sbt-test/dumpLicenseReport/empty-url-report/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.github.sbt" % "sbt-license-report" % x)
+  case _       => sys.error("""|The system property 'plugin.version' is not defined.
+                               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/dumpLicenseReport/empty-url-report/test
+++ b/src/sbt-test/dumpLicenseReport/empty-url-report/test
@@ -1,0 +1,5 @@
+> dumpLicenseReport
+$ exists target/license-reports/example-licenses.md
+$ exists target/license-reports/example-licenses.html
+$ exists target/license-reports/example-licenses.csv
+> check


### PR DESCRIPTION
Some Libraries indicate a license without a url which gets defaulted into `NoneSpecified` which breaks license categorization for these libraries

This change fixes that problem